### PR TITLE
Allow the session data to be updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class SqliteStore extends EventEmitter {
     }
 
     super()
-    this.setSession = sqlite3db.prepare(`INSERT OR REPLACE INTO ${table} (sid, expires, session) VALUES (?, ?, ?)`)
+    this.setSession = sqlite3db.prepare(`INSERT INTO ${table} (sid, expires, session) VALUES (?, ?, ?) ON CONFLICT (sid) DO UPDATE SET session = excluded.session`)
     this.getSession = sqlite3db.prepare(`SELECT sid, expires, session FROM ${table} WHERE sid = ?`)
     this.destroySession = sqlite3db.prepare(`DELETE FROM ${table} WHERE sid = ?`)
   }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class SqliteStore extends EventEmitter {
     }
 
     super()
-    this.setSession = sqlite3db.prepare(`INSERT INTO ${table} (sid, expires, session) VALUES (?, ?, ?)`)
+    this.setSession = sqlite3db.prepare(`INSERT OR REPLACE INTO ${table} (sid, expires, session) VALUES (?, ?, ?)`)
     this.getSession = sqlite3db.prepare(`SELECT sid, expires, session FROM ${table} WHERE sid = ?`)
     this.destroySession = sqlite3db.prepare(`DELETE FROM ${table} WHERE sid = ?`)
   }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ class SqliteStore extends EventEmitter {
     }
 
     super()
-    this.setSession = sqlite3db.prepare(`INSERT INTO ${table} (sid, expires, session) VALUES (?, ?, ?) ON CONFLICT (sid) DO UPDATE SET session = excluded.session`)
+    this.setSession = sqlite3db.prepare(`INSERT INTO ${table} (sid, expires, session) VALUES (?, ?, ?) ON CONFLICT (sid) DO UPDATE SET session = excluded.session, expires = excluded.expires`)
     this.getSession = sqlite3db.prepare(`SELECT sid, expires, session FROM ${table} WHERE sid = ?`)
     this.destroySession = sqlite3db.prepare(`DELETE FROM ${table} WHERE sid = ?`)
   }


### PR DESCRIPTION
Currently session data can not be updated in the store.
This pull request adjusts the SQL set by `this.setSession` that is used by the `SqliteStore.prototype.set` method so that on a conflict of the `sid` column it will do an `UPDATE` on the `session` column with the updated data rather than silently failing 

I initially changed to `INSERT OR REPLACE` but changed my mind and decided to go with the `ON CONFLICT` route instead

Edit: Adjusted so the `expires` column is also updated when the session data is updated